### PR TITLE
Transition to EBS Auto-Scaling and Remove Fusion for Batch Jobs

### DIFF
--- a/bin/settings.ts
+++ b/bin/settings.ts
@@ -24,7 +24,7 @@ export const SETTINGS: OncoanalyserProps = {
         ec2.InstanceType.of(ec2.InstanceClass.R6A, ec2.InstanceSize.LARGE),
     ],
     taskInstanceTypes: [
-        ec2.InstanceType.of(ec2.InstanceClass.R6ID, ec2.InstanceSize.LARGE),
+        ec2.InstanceType.of(ec2.InstanceClass.R6I, ec2.InstanceSize.LARGE),
     ],
     vpc: undefined,
 };

--- a/lib/application-stack.ts
+++ b/lib/application-stack.ts
@@ -97,7 +97,6 @@ export class Oncoanalyser extends Construct {
         vpcSubnets: {
           subnetType: ec2.SubnetType.PUBLIC,
         },
-
       },
     );
 

--- a/lib/application-stack.ts
+++ b/lib/application-stack.ts
@@ -379,7 +379,7 @@ rm -rf /tmp/awscliv2.zip /tmp/aws/ /tmp/amazon-ebs-autoscale/
       },
     );
 
-    cdk.Tags.of(launchTemplate).add("Name", "nextflow");
+    cdk.Tags.of(launchTemplate).add("Name", ltName);
     return launchTemplate;
   }
 }

--- a/lib/resources/nextflow_aws.template.config
+++ b/lib/resources/nextflow_aws.template.config
@@ -2,18 +2,10 @@ plugins {
   id 'nf-amazon'
 }
 
-fusion {
-  enabled = true
-}
-
-wave {
-  enabled = true
-}
-
 aws {
   batch {
     jobRole = '{{BATCH_INSTANCE_TASK_ROLE_ARN}}'
-    volumes = '{{BATCH_VOLUME_MOUNT_POINT}}:/tmp/'
+    volumes = '/scratch'
   }
 }
 
@@ -37,7 +29,7 @@ params {
 
 process {
   executor = 'awsbatch'
-  scratch = false
+  scratch = '/scratch/'
 
   // NOTE(SW): using docker.runOptions in 23.10.01 causes `--network host` to be included twice, triggering an error in Docker
   containerOptions = '--network host'


### PR DESCRIPTION
This PR removes Fusion and standardizes the batch processing pipeline to use EBS auto-scaling, as discussed in issue #5.

Changes 

- Removed BATCH_VOLUME_MOUNT_POINT, which was previously used for Fusion.
- Use a single LaunchTemplate Pipeline and Task