### PR TITLE
feat: offline plugins

### DIFF
--- a/bin/oncoanalyser-stack.ts
+++ b/bin/oncoanalyser-stack.ts
@@ -4,7 +4,7 @@ import * as cdk from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 import { Oncoanalyser, OncoanalyserProps } from "../lib/application-stack";
-import {SETTINGS} from "./settings";
+import { SETTINGS } from "./settings";
 
 export class OncoanalyserStack extends cdk.Stack {
   constructor(

--- a/bin/settings.ts
+++ b/bin/settings.ts
@@ -5,26 +5,26 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
  * Configurable settings for the oncoanalyser construct.
  */
 export const SETTINGS: OncoanalyserProps = {
-    bucket: {
-        bucket: "umccr-temp-dev",
-        inputPrefix: "inputs",
-        outputPrefix: "outputs",
-        refDataPrefix: "refdata",
-    },
-    docker: {
-        ecrRepo: "oncoanalyser",
-        dockerImageTag: "latest-pmcc",
-    },
-    // NOTE(SW): temporary reduction for testing during dev
-    //maxPipelineCpus: 64,
-    //maxTaskCpus: 256,
-    maxPipelineCpus: 2,
-    maxTaskCpus: 4,
-    pipelineInstanceTypes: [
-        ec2.InstanceType.of(ec2.InstanceClass.R6A, ec2.InstanceSize.LARGE),
-    ],
-    taskInstanceTypes: [
-        ec2.InstanceType.of(ec2.InstanceClass.R6ID, ec2.InstanceSize.LARGE),
-    ],
-    vpc: undefined,
+  bucket: {
+    bucket: "umccr-temp-dev",
+    inputPrefix: "inputs",
+    outputPrefix: "outputs",
+    refDataPrefix: "refdata",
+  },
+  docker: {
+    ecrRepo: "oncoanalyser",
+    dockerImageTag: "latest-pmcc",
+  },
+  // NOTE(SW): temporary reduction for testing during dev
+  //maxPipelineCpus: 64,
+  //maxTaskCpus: 256,
+  maxPipelineCpus: 2,
+  maxTaskCpus: 4,
+  pipelineInstanceTypes: [
+    ec2.InstanceType.of(ec2.InstanceClass.R6A, ec2.InstanceSize.LARGE),
+  ],
+  taskInstanceTypes: [
+    ec2.InstanceType.of(ec2.InstanceClass.R6ID, ec2.InstanceSize.LARGE),
+  ],
+  vpc: undefined,
 };

--- a/lib/application-stack.ts
+++ b/lib/application-stack.ts
@@ -16,8 +16,9 @@ import * as ssm from "aws-cdk-lib/aws-ssm";
 import * as Handlebars from "handlebars";
 import * as ecrDeployment from "cdk-ecr-deployment";
 import { Aws } from "aws-cdk-lib";
-import {ContainerImage} from "aws-cdk-lib/aws-ecs";
-import {Platform} from "aws-cdk-lib/aws-ecr-assets";
+import { ContainerImage } from "aws-cdk-lib/aws-ecs";
+import { Platform } from "aws-cdk-lib/aws-ecr-assets";
+import { NEXTFLOW_PLUGINS } from "./dependencies";
 
 const BATCH_VOLUME_MOUNT_POINT = "/mnt/local_ephemeral/"
 
@@ -265,7 +266,10 @@ export class Oncoanalyser extends Construct {
     // Create Docker image and deploy
     const image = new ecrAssets.DockerImageAsset(this, 'DockerImage', {
       directory: path.join(__dirname, 'resources'),
-      platform: Platform.LINUX_AMD64
+      platform: Platform.LINUX_AMD64,
+      buildArgs: {
+        NEXTFLOW_PLUGINS: NEXTFLOW_PLUGINS.join(",")
+      }
     });
 
     // Bucket permissions
@@ -308,8 +312,11 @@ export class Oncoanalyser extends Construct {
       BATCH_JOB_QUEUE_NAME: jobQueueTask.jobQueueName,
       S3_BUCKET_NAME: props.bucket.bucket,
       S3_BUCKET_REFDATA_PREFIX: props.bucket.refDataPrefix,
-      BATCH_VOLUME_MOUNT_POINT: BATCH_VOLUME_MOUNT_POINT
+      BATCH_VOLUME_MOUNT_POINT: BATCH_VOLUME_MOUNT_POINT,
+      PLUGINS: NEXTFLOW_PLUGINS,
     }, { });
+
+    console.log(nextflowConfig);
 
     // Create job definition for pipeline execution
     const jobDefinition = new batch.EcsJobDefinition(this, "JobDefinition", {

--- a/lib/dependencies.ts
+++ b/lib/dependencies.ts
@@ -1,0 +1,8 @@
+/**
+ * Define the required Nextflow plugins.
+ */
+export const NEXTFLOW_PLUGINS: string[] = [
+  "nf-amazon@2.9.2",
+  "nf-schema@2.3.0",
+  "nf-wave@1.7.4",
+];

--- a/lib/resources/Dockerfile
+++ b/lib/resources/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker.io/continuumio/miniconda3:25.1.1-2
 
+ARG NEXTFLOW_PLUGINS
+
 # Configure Conda
 RUN \
   echo '\
@@ -18,6 +20,9 @@ RUN \
     'nextflow=24.10.4' \
     'openjdk=17.0.10' && \
   conda clean -yaf
+
+# Install plugins for offline usage
+RUN nextflow plugin install ${NEXTFLOW_PLUGINS}
 
 # Install oncoanalyser and config template
 RUN \

--- a/lib/resources/nextflow_aws.template.config
+++ b/lib/resources/nextflow_aws.template.config
@@ -1,5 +1,7 @@
 plugins {
-  id 'nf-amazon'
+  {{#PLUGINS}}
+    id '{{.}}'
+  {{/PLUGINS}}
 }
 
 fusion {


### PR DESCRIPTION
Closes #6 

### Changes
* Specifies plugins in the template and inside the dockerfile to install them while the dockerfile is built.

I think it makes sense to pin the plugin versions so that it's always offline, and newer ones aren't downloaded, like the docs suggest: https://www.nextflow.io/docs/latest/plugins.html#offline-usage