### PR TITLE
Add AMI ebs-autoscalling

### DIFF
--- a/lib/nextflow-pipeline-environment/index.ts
+++ b/lib/nextflow-pipeline-environment/index.ts
@@ -194,6 +194,26 @@ export class NextflowPipelineEnvironment extends Construct {
       ],
     });
 
+    new Policy(this, "PipelinePolicyEBSAutoscale", {
+      roles: [instanceRole],
+      statements: [
+        new PolicyStatement({
+          actions: [
+            "ec2:AttachVolume",
+            "ec2:DescribeVolumeStatus",
+            "ec2:DescribeVolumes",
+            "ec2:DescribeTags",
+            "ec2:ModifyInstanceAttribute",
+            "ec2:DescribeVolumeAttribute",
+            "ec2:CreateVolume",
+            "ec2:DeleteVolume",
+            "ec2:CreateTags"
+          ],
+          resources: ["*"],
+        }),
+      ],
+    });
+
     new Policy(this, "PipelinePolicyECR", {
       roles: [instanceRole],
       statements: [


### PR DESCRIPTION
(copy previous PR restarted because too much changes on main)


address #25 

log form **cloud-init-output.log** 
```bash
Cloning into '/tmp/amazon-ebs-autoscale'...
Note: switching to '6db0c70'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 6db0c70 Merge pull request #74 from scwatts/update_IMDSV2_support
++ cat
+ USAGE='Install Amazon EBS Autoscale

    /tmp/amazon-ebs-autoscale/install.sh [options] [[-m] <mount-point>]

Options

    -d, --initial-device DEVICE
                        Initial device to use for mountpoint - e.g. /dev/xvdba.
                        (Default: none - automatically create and attaches a volume)
                        If provided --initial-size is ignored.

    -f, --file-system   btrfs | lvm.ext4
                        Filesystem to use (default: btrfs).
                        Options are btrfs or lvm.ext4

    -h, --help
                        Print help and exit.

    -m, --mountpoint    MOUNTPOINT
                        Mount point for autoscale volume (default: /scratch)

    -t, --volume-type   VOLUMETYPE
                        Volume type (default: gp3)

    --volume-iops       VOLUMEIOPS
                        Volume IOPS for gp3, io1, io2 (default: 3000)

    --volume-throughput VOLUMETHOUGHPUT
                        Volume throughput for gp3 (default: 125)

    --min-ebs-volume-size SIZE_GB
                        Mimimum size in GB of new volumes created by the instance.
                        (Default: 150)

    --max-ebs-volume-size SIZE_GB
                        Maximum size in GB of new volumes created by the instance.
                        (Default: 1500)

    --max-total-created-size SIZE_GB
                        Maximum total size in GB of all volumes created by the instance.
                        (Default: 8000)

    --max-attached-volumes N
                        Maximum number of attached volumes. (Default: 16)

    --initial-utilization-threshold N
                        Initial disk utilization treshold for scale-up. (Default: 50)

    -s, --initial-size  SIZE_GB
                        Initial size of the volume in GB. (Default: 200)
                        Only used if --initial-device is NOT specified.

    -i, --imdsv2
                        Enable imdsv2 for instance metadata API requests.
    '
+ MOUNTPOINT=/scratch
+ SIZE=200
+ VOLUMETYPE=gp3
+ VOLUMEIOPS=3000
+ VOLUMETHOUGHPUT=125
+ MIN_EBS_VOLUME_SIZE=150
+ MAX_EBS_VOLUME_SIZE=1500
+ MAX_LOGICAL_VOLUME_SIZE=8000
+ MAX_ATTACHED_VOLUMES=16
+ INITIAL_UTILIZATION_THRESHOLD=50
+ IMDSV2=
+ DEVICE=
+ FILE_SYSTEM=btrfs
++ dirname /tmp/amazon-ebs-autoscale/install.sh
+ BASEDIR=/tmp/amazon-ebs-autoscale
+ . /tmp/amazon-ebs-autoscale/shared/utils.sh
+ PARAMS=
+ ((  0  ))
+ eval set -- ''
++ set --
+ initialize
++ get_metadata placement/availability-zone
++ local key=placement/availability-zone
++ local metadata_ip=169.254.169.254
++ '[' '!' -z '' ']'
+++ curl -s -H 'X-aws-ec2-metadata-token: ' http://169.254.169.254/latest/meta-data/placement/availability-zone
++ echo ap-southeast-2b
+ export AWS_AZ=ap-southeast-2b
+ AWS_AZ=ap-southeast-2b
++ sed -e 's/[a-z]$//'
++ echo ap-southeast-2b
+ export AWS_REGION=ap-southeast-2
+ AWS_REGION=ap-southeast-2
++ get_metadata instance-id
++ local key=instance-id
++ local metadata_ip=169.254.169.254
++ '[' '!' -z '' ']'
+++ curl -s -H 'X-aws-ec2-metadata-token: ' http://169.254.169.254/latest/meta-data/instance-id
++ echo i-07a7d634caccb7959
+ export INSTANCE_ID=i-07a7d634caccb7959
+ INSTANCE_ID=i-07a7d634caccb7959
+ '[' '!' -z '' ']'
+ mkdir -p /usr/local/amazon-ebs-autoscale/bin /usr/local/amazon-ebs-autoscale/shared
+ cp /tmp/amazon-ebs-autoscale/bin/create-ebs-volume /tmp/amazon-ebs-autoscale/bin/ebs-autoscale /usr/local/amazon-ebs-autoscale/bin
+ chmod +x /usr/local/amazon-ebs-autoscale/bin/create-ebs-volume /usr/local/amazon-ebs-autoscale/bin/ebs-autoscale
+ ln -sf /usr/local/amazon-ebs-autoscale/bin/create-ebs-volume /usr/local/amazon-ebs-autoscale/bin/ebs-autoscale /usr/local/bin/
+ ln -sf /usr/local/amazon-ebs-autoscale/bin/create-ebs-volume /usr/local/amazon-ebs-autoscale/bin/ebs-autoscale /usr/bin/
+ cp /tmp/amazon-ebs-autoscale/shared/utils.sh /usr/local/amazon-ebs-autoscale/shared
+ cp /tmp/amazon-ebs-autoscale/config/ebs-autoscale.logrotate /etc/logrotate.d/ebs-autoscale
+ sed -e s#%%IMDSV2%%##
+ sed -e s#%%MINEBSVOLUMESIZE%%#150#
+ sed -e s#%%MAXEBSVOLUMESIZE%%#1500#
+ sed -e s#%%MAXLOGICALVOLUMESIZE%%#8000#
+ sed -e s#%%MAXATTACHEDVOLUMES%%#16#
+ sed -e s#%%INITIALUTILIZATIONTHRESHOLD%%#50#
+ sed -e s#%%FILESYSTEM%%#btrfs#
+ sed -e s#%%VOLUMETHOUGHPUT%%#125#
+ sed -e s#%%VOLUMEIOPS%%#3000#
+ sed -e s#%%VOLUMETYPE%%#gp3#
+ sed -e s#%%MOUNTPOINT%%#/scratch#
+ cat /tmp/amazon-ebs-autoscale/config/ebs-autoscale.json
+ '[' -e /scratch ']'
+ '[' -e /scratch ']'
+ mkdir -p /scratch
+ '[' -z '' ']'
++ create-ebs-volume --size 200 --type gp3
+ DEVICE=/dev/xvdba
+ '[' btrfs = btrfs ']'
+ mkfs.btrfs -f -d single /dev/xvdba
btrfs-progs v4.15.1
See http://btrfs.wiki.kernel.org for more information.

Detected a SSD, turning off metadata duplication.  Mkfs with -m dup if you want to force metadata duplication.
Label:              (null)
UUID:               1c3cc0fe-5591-492a-8652-8d207e80a0df
Node size:          16384
Sector size:        4096
Filesystem size:    200.00GiB
Block group profiles:
  Data:             single            8.00MiB
  Metadata:         single            8.00MiB
  System:           single            4.00MiB
SSD detected:       yes
Incompat features:  extref, skinny-metadata
Number of devices:  1
Devices:
   ID        SIZE  PATH
    1   200.00GiB  /dev/xvdba

+ mount /dev/xvdba /scratch
+ tee -a /etc/fstab
+ echo -e '/dev/xvdba\t/scratch\tbtrfs\tdefaults\t0\t0'
/dev/xvdba	/scratch	btrfs	defaults	0	0
+ chmod 1777 /scratch
++ detect_init_system
+ INIT_SYSTEM=systemd
+ case $INIT_SYSTEM in
+ echo 'systemd detected'
systemd detected
+ cd /tmp/amazon-ebs-autoscale/service/systemd
+ . ./install.sh
++ cp ebs-autoscale.service /usr/lib/systemd/system/ebs-autoscale.service
++ systemctl daemon-reload
++ systemctl enable ebs-autoscale.service
Created symlink from /etc/systemd/system/multi-user.target.wants/ebs-autoscale.service to /usr/lib/systemd/system/ebs-autoscale.service.
++ systemctl start ebs-autoscale.service
+ cd /tmp/amazon-ebs-autoscale
ci-info: no authorized ssh keys fingerprints found for user ec2-user.
Cloud-init v. 19.3-46.amzn2.0.4 finished at Tue, 04 Mar 2025 04:09:07 +0000. Datasource DataSourceEc2.  Up 46.54 seconds
```